### PR TITLE
fix: paint the verse highlight on text runs, not the inline host

### DIFF
--- a/src/app/components/verse/verse.component.css
+++ b/src/app/components/verse/verse.component.css
@@ -109,3 +109,80 @@ h3:not(:first-child) {
   cursor: pointer;
   outline: none;
 }
+
+/*
+ * Deep-link / search highlight: a marker stroke swept over the verse.
+ *
+ * It is painted on the text runs themselves, never on the <verse> host or on
+ * the boxes that lay the verse out. The host is an inline box, so a background
+ * on it also covers the empty line fragments left behind by <br> and the spaces
+ * that separate verses (stray blocks of colour) while never reaching the poetry
+ * verse numbers, which hang outside the line box via position: absolute; and
+ * .quoteLineWrapper is an inline-block, so painting it fills the whole
+ * rectangle including the empty space after a short line of poetry.
+ *
+ * The stroke is a background-image rather than a background-colour so it can be
+ * swept in from the left: with the default box-decoration-break: slice the
+ * fragments of a wrapped run share one background area, so the sweep runs
+ * across the whole verse like a pen instead of restarting on every line.
+ * Vertical padding thickens the stroke without touching layout — only
+ * horizontal padding advances inline boxes, so nothing reflows when the
+ * highlight comes and goes.
+ */
+.verseRun,
+.verseNumber,
+.footnoteIndicator,
+.quoteVerseNumber {
+  background-image: linear-gradient(
+    var(--verse-highlight-color),
+    var(--verse-highlight-color)
+  );
+  background-repeat: no-repeat;
+  background-position: left center;
+  background-size: 0 100%;
+  border-radius: 0.15em;
+  transition: background-size 0.45s ease;
+}
+
+:host(.verse-highlight) .verseRun,
+:host(.verse-highlight) .verseNumber,
+:host(.verse-highlight) .footnoteIndicator {
+  background-size: 100% 100%;
+}
+
+:host(.verse-highlight) .verseRun {
+  padding-block: 0.1em;
+}
+
+/* Verse numbers and footnote markers are set at 65% and hang from the top of
+   the line (vertical-align: top), so an even padding would leave them as short
+   tiles floating above the stroke; padding-block is relative to their own
+   font-size, hence the much larger value needed to reach the text's band.
+   Padding is applied only while highlighted: it never moves an inline box, but
+   the footnote marker is a button and its hit area should not grow. */
+:host(.verse-highlight) .verseNumber,
+:host(.verse-highlight) .footnoteIndicator {
+  padding-block: 0.05em 1.45em;
+}
+
+/* In poetry the number hangs off the left of its line (position: absolute).
+   The stroke goes on the wrapper, which is already the height of the line, and
+   its children stop painting so the translucent colour is not laid down twice. */
+:host(.verse-highlight) .quoteVerseNumber {
+  background-size: 100% 100%;
+}
+
+:host(.verse-highlight) .quoteVerseNumber .verseNumber,
+:host(.verse-highlight) .quoteVerseNumber .footnoteIndicator {
+  background-size: 0 100%;
+  padding-block: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .verseRun,
+  .verseNumber,
+  .footnoteIndicator,
+  .quoteVerseNumber {
+    transition: none;
+  }
+}

--- a/src/app/components/verse/verse.component.html
+++ b/src/app/components/verse/verse.component.html
@@ -2,7 +2,10 @@
   <!-- Verse Number -->
   @if(data.number > 0 && getFirstTextType() !== 'quote'){
     @if(data.number > 1) {
-      {{ " " }}
+      <!-- The gap between two verses is part of the run so the highlight stroke
+           does not break in front of every verse number; .verseText keeps it the
+           same size as the text it separates. -->
+      <span class="verseText verseRun">{{ " " }}</span>
     }
     <span class="verseNumber">{{ data.number }}</span>
     @if(hasFootnotes){
@@ -31,7 +34,7 @@
             }
           </span>
         }
-        <span [attr.tabindex]="hasFootnotes ? 0 : null" [attr.role]="hasFootnotes ? 'button' : null" [ngClass]="{'allCaps': text.allCaps}" [class.interactive]="hasFootnotes" (click)="hasFootnotes ? toggleFootnotes($event) : null" (keydown.enter)="hasFootnotes ? toggleFootnotes($event) : null" (keydown.space)="$event.preventDefault(); toggleFootnotes($event)">{{ text.text }}</span>
+        <span class="verseRun" [attr.tabindex]="hasFootnotes ? 0 : null" [attr.role]="hasFootnotes ? 'button' : null" [ngClass]="{'allCaps': text.allCaps}" [class.interactive]="hasFootnotes" (click)="hasFootnotes ? toggleFootnotes($event) : null" (keydown.enter)="hasFootnotes ? toggleFootnotes($event) : null" (keydown.space)="$event.preventDefault(); toggleFootnotes($event)">{{ text.text }}</span>
       }
 
       <!-- References -->
@@ -41,13 +44,13 @@
           <span class="references-block">
             @for(part of parsedReferences.get(i); track $index){
               @if(typeof part === "object" && part.book !== data.bookId){
-                <a class="references"
+                <a class="references verseRun"
                   [routerLink]="['/', (part.book | lowercase ), part.chapter]"
                   [queryParams]="getVerseQueryParams(part.verses, part.crossChapter)"
                   >{{part.match}}</a
                   >
                 } @else {
-                  <span class="references">{{typeof part === "object" ? part.match : part}}</span>
+                  <span class="references verseRun">{{typeof part === "object" ? part.match : part}}</span>
                 }
               }
             </span>
@@ -67,13 +70,13 @@
           @if (!isFirst && isLast && chapterNumberDisplayIndex !== i && !shouldShowParagraph(data, text, i)) {
             <span>
               <br>
-              <span #indentable [attr.data-index]="i" [class.indent]="indentStates[i] !== false">
+              <span #indentable class="verseRun" [attr.data-index]="i" [class.indent]="indentStates[i] !== false">
                 {{ text.text }}
               </span>
             </span>
           }
           @if (shouldShowParagraph(data, text, i)) {
-            <span #indentable [attr.data-index]="i" [class.indent]="indentStates[i] !== false">
+            <span #indentable class="verseRun" [attr.data-index]="i" [class.indent]="indentStates[i] !== false">
               {{ text.text }}
             </span>
           }

--- a/src/app/components/verse/verse.component.spec.ts
+++ b/src/app/components/verse/verse.component.spec.ts
@@ -488,6 +488,107 @@ describe("VerseComponent", () => {
     })
   })
 
+  describe("deep-link highlight", () => {
+    /** Mirrors what BibleReaderAnimationService puts on the <verse> host. */
+    function highlightHost(): HTMLElement {
+      const host = fixture.nativeElement as HTMLElement
+      host.classList.add("verse-highlight")
+      fixture.detectChanges()
+      return host
+    }
+
+    it("should mark the text run so the stroke can be painted on it", () => {
+      setData(component, makeVerse({ text: [{ type: "text", text: "plain" }] }))
+      highlightHost()
+
+      const run = fixture.nativeElement.querySelector(
+        ".verseRun",
+      ) as HTMLElement
+      expect(run.textContent).toContain("plain")
+      expect(getComputedStyle(run).backgroundSize).toBe("100% 100%")
+    })
+
+    it("should leave the run unpainted while the verse is not highlighted", () => {
+      setData(component, makeVerse({ text: [{ type: "text", text: "plain" }] }))
+      fixture.detectChanges()
+
+      const run = fixture.nativeElement.querySelector(
+        ".verseRun",
+      ) as HTMLElement
+      expect(getComputedStyle(run).backgroundSize).toBe("0px 100%")
+    })
+
+    it("should never paint the inline host, whose line fragments would colour the gaps between verses", () => {
+      setData(component, makeVerse({ text: [{ type: "text", text: "plain" }] }))
+      const host = highlightHost()
+
+      const style = getComputedStyle(host)
+      expect(style.backgroundImage).toBe("none")
+      expect(style.backgroundColor).toBe("rgba(0, 0, 0, 0)")
+    })
+
+    it("should paint the verse number so it is not left out of the stroke", () => {
+      setData(
+        component,
+        makeVerse({ number: 2, text: [{ type: "text", text: "plain" }] }),
+      )
+      highlightHost()
+
+      const number = fixture.nativeElement.querySelector(
+        ".verseNumber",
+      ) as HTMLElement
+      expect(getComputedStyle(number).backgroundSize).toBe("100% 100%")
+    })
+
+    it("should wrap the space in front of a verse number in a run so the stroke does not break", () => {
+      setData(
+        component,
+        makeVerse({ number: 2, text: [{ type: "text", text: "plain" }] }),
+      )
+      highlightHost()
+
+      const gap = fixture.nativeElement.querySelector(
+        ".verseRun",
+      ) as HTMLElement
+      expect(gap.textContent).toBe(" ")
+      expect(getComputedStyle(gap).backgroundSize).toBe("100% 100%")
+    })
+
+    it("should paint a poetry verse number once, on the wrapper rather than on both it and its digits", () => {
+      setData(
+        component,
+        makeVerse({
+          number: 3,
+          text: [{ type: "quote", text: "a line of poetry", identLevel: 1 }],
+        }),
+      )
+      highlightHost()
+
+      const wrapper = fixture.nativeElement.querySelector(
+        ".quoteVerseNumber",
+      ) as HTMLElement
+      const digits = wrapper.querySelector(".verseNumber") as HTMLElement
+      expect(getComputedStyle(wrapper).backgroundSize).toBe("100% 100%")
+      expect(getComputedStyle(digits).backgroundSize).toBe("0px 100%")
+    })
+
+    it("should not paint the quote line wrapper, whose box extends past the end of the line", () => {
+      setData(
+        component,
+        makeVerse({
+          number: 3,
+          text: [{ type: "quote", text: "a line of poetry", identLevel: 1 }],
+        }),
+      )
+      highlightHost()
+
+      const wrapper = fixture.nativeElement.querySelector(
+        ".quoteLineWrapper",
+      ) as HTMLElement
+      expect(getComputedStyle(wrapper).backgroundSize).toBe("auto")
+    })
+  })
+
   describe("toggleFootnotes", () => {
     it("should open bottom sheet when footnotes exist", () => {
       setData(

--- a/src/app/services/bible-reader-animation.service.spec.ts
+++ b/src/app/services/bible-reader-animation.service.spec.ts
@@ -1,5 +1,9 @@
 import { fakeAsync, TestBed, tick } from "@angular/core/testing"
-import { BibleReaderAnimationService } from "./bible-reader-animation.service"
+import {
+  BibleReaderAnimationService,
+  HIGHLIGHT_CLASS,
+  HIGHLIGHT_DURATION_MS,
+} from "./bible-reader-animation.service"
 
 describe("BibleReaderAnimationService", () => {
   let service: BibleReaderAnimationService
@@ -196,10 +200,61 @@ describe("BibleReaderAnimationService", () => {
       tick(100)
 
       expect(verse1.scrollIntoView).toHaveBeenCalled()
-      expect(verse1.style.backgroundColor).toBe("var(--highlight-color)")
-
-      tick(2500)
+      expect(verse1.classList.contains(HIGHLIGHT_CLASS)).toBeTrue()
+      // The stroke is drawn by the verse component's own styles; painting the
+      // inline host from here is what used to colour whitespace and gaps.
       expect(verse1.style.backgroundColor).toBe("")
+
+      tick(HIGHLIGHT_DURATION_MS)
+      expect(verse1.classList.contains(HIGHLIGHT_CLASS)).toBeFalse()
+    }))
+
+    it("should restart the fade when the same verse is highlighted again", fakeAsync(() => {
+      const bookBlock = document.createElement("div")
+      const verse1 = document.createElement("div")
+      verse1.id = "1"
+      bookBlock.appendChild(verse1)
+      spyOn(verse1, "scrollIntoView")
+
+      service.scrollToVerseElement(bookBlock, undefined, 1, 1, true, false)
+      tick(100)
+      tick(HIGHLIGHT_DURATION_MS - 500)
+
+      service.scrollToVerseElement(bookBlock, undefined, 1, 1, true, false)
+      tick(100)
+
+      // The first timeout would have fired by now had it not been cleared.
+      tick(500)
+      expect(verse1.classList.contains(HIGHLIGHT_CLASS)).toBeTrue()
+
+      tick(HIGHLIGHT_DURATION_MS)
+      expect(verse1.classList.contains(HIGHLIGHT_CLASS)).toBeFalse()
+    }))
+
+    it("should highlight every verse of a range", fakeAsync(() => {
+      const bookBlock = document.createElement("div")
+      const verses = [1, 2, 3].map((n) => {
+        const el = document.createElement("div")
+        el.id = String(n)
+        bookBlock.appendChild(el)
+        spyOn(el, "scrollIntoView")
+        return el
+      })
+
+      service.scrollToVerseElement(bookBlock, undefined, 1, 3, true, false)
+      tick(100)
+
+      expect(
+        verses.every((el) => el.classList.contains(HIGHLIGHT_CLASS)),
+      ).toBeTrue()
+      // Only the first verse of the range is scrolled into view.
+      expect(verses[0].scrollIntoView).toHaveBeenCalled()
+      expect(verses[1].scrollIntoView).not.toHaveBeenCalled()
+
+      tick(HIGHLIGHT_DURATION_MS)
+      expect(
+        verses.some((el) => el.classList.contains(HIGHLIGHT_CLASS)),
+      ).toBeFalse()
     }))
 
     it("should do nothing if bookBlock is undefined", fakeAsync(() => {
@@ -237,7 +292,7 @@ describe("BibleReaderAnimationService", () => {
       tick(100)
 
       expect(verse1.scrollIntoView).toHaveBeenCalled()
-      expect(verse1.style.backgroundColor).not.toBe("var(--highlight-color)")
+      expect(verse1.classList.contains(HIGHLIGHT_CLASS)).toBeFalse()
       expect(service.triggerSlideAnimation).toHaveBeenCalledWith(
         undefined,
         bookContainer,

--- a/src/app/services/bible-reader-animation.service.ts
+++ b/src/app/services/bible-reader-animation.service.ts
@@ -1,5 +1,11 @@
 import { Injectable } from "@angular/core"
 
+/** Toggled on the <verse> host; the stroke is styled in verse.component.css. */
+export const HIGHLIGHT_CLASS = "verse-highlight"
+
+/** How long a deep-linked verse stays marked before the stroke fades out. */
+export const HIGHLIGHT_DURATION_MS = 2500
+
 @Injectable({
   providedIn: "root",
 })
@@ -156,17 +162,19 @@ export class BibleReaderAnimationService {
             scrolled = true
           }
           if (highlight) {
-            element.style.transition = "background-color 0.5s ease"
-            element.style.backgroundColor = "var(--highlight-color)"
+            // The stroke itself is styled by the verse component; painting it
+            // from here (on the inline <verse> host) would colour the empty
+            // line fragments and inter-verse spaces too.
+            element.classList.add(HIGHLIGHT_CLASS)
 
             if (this.highlightTimeouts.has(element)) {
               clearTimeout(this.highlightTimeouts.get(element))
             }
 
             const timeoutId = setTimeout(() => {
-              element.style.backgroundColor = ""
+              element.classList.remove(HIGHLIGHT_CLASS)
               this.highlightTimeouts.delete(element)
-            }, 2500)
+            }, HIGHLIGHT_DURATION_MS)
             this.highlightTimeouts.set(element, timeoutId)
           }
         }

--- a/src/styles.css
+++ b/src/styles.css
@@ -75,6 +75,10 @@ body {
   --card-background: #f5f5f5;
   --border-color: #e0e0e0;
   --highlight-color: antiquewhite;
+  /* Marker drawn over a deep-linked verse. Kept separate from
+     --highlight-color (a solid surface colour used by buttons and lists)
+     because it is painted over body text and has to stay readable. */
+  --verse-highlight-color: rgba(238, 176, 46, 0.42);
   --cap-brown: #543d27;
   --mat-menu-item-label-text-size: 15px;
   --mat-menu-container-color: var(--card-background);
@@ -126,6 +130,9 @@ body {
   --card-background: #1e1e1e;
   --border-color: #333333;
   --highlight-color: darkgrey;
+  /* Same hue as the light theme, lighter touch: white text has to stay
+     readable on top of it. */
+  --verse-highlight-color: rgba(238, 176, 46, 0.3);
   --mat-menu-container-color: var(--card-background);
   --mat-menu-item-label-text-color: var(--text-color);
   --mat-menu-item-icon-color: var(--text-color);


### PR DESCRIPTION
## What was wrong

Deep-linking to a verse (`/jo/3?verseStart=16`) set an inline `background-color` on the `<verse>` host. That host is `display: inline`, so the colour landed on **every line fragment it generates** — the empty fragment left behind by the `<br>` in poetry verses, and the space that separates one verse from the next — while never reaching the poetry verse numbers, which hang outside the line box via `position: absolute`. Where it did reach `.quoteLineWrapper` (an inline-block), a four-word line of poetry got a full-width slab of colour.

So: parts of the verse unhighlighted, whitespace highlighted, and slabs in the Psalms.

## What changed

The service toggles a `verse-highlight` class on the host and the verse component paints the **text runs themselves**:

- an explicit `.verseRun` on every run, including the space in front of a verse number, so the stroke doesn't break at every verse boundary;
- verse numbers and footnote markers (65%, `vertical-align: top`) padded down onto the text's band instead of floating above it as short tiles;
- in poetry, the stroke goes on the absolutely positioned number wrapper (and off its children, so the translucent colour isn't laid down twice);
- nothing that lays the verse out is painted — no slabs, no coloured whitespace.

While in there, the look got a revamp: its own `--verse-highlight-color` token per theme (dark mode previously put white text on `darkgrey`), rounded ends, and a `background-size` sweep so it draws in from the left across the whole verse like a highlighter pen rather than restarting on every wrapped line. Vertical padding thickens the stroke without moving any text — only horizontal padding advances inline boxes — so nothing reflows when the highlight comes and goes. `prefers-reduced-motion` drops the sweep.

## Notes for review

- The CSS deliberately paints runs and not containers; the comment block in `verse.component.css` records why, so the next person doesn't "simplify" it back onto the host.
- `padding-block: 0.05em 1.45em` on verse numbers is tuned against their 65% font-size and the unitless `line-height: 1.6`, so it holds across the reader's font-size controls. Applied only while highlighted, so the footnote marker's hit area never grows.
- Verified live in the browser on the real deep-link flow (`/sl/23?verseStart=1&verseEnd=4`, `/jo/3?verseStart=16&verseEnd=17`) in prose, poetry, and both themes.
- Tests: the service specs now cover class toggling, whole-range highlighting and the fade restarting when the same verse is re-linked; `verse.component.spec.ts` pins the painting contract, including that the host is never painted. Lint, typecheck and all 415 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
